### PR TITLE
Add SSH terminal colorization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ PREFIX?=	/usr/local
 
 SRCS=		calmwm.c screen.c xmalloc.c client.c menu.c \
 		search.c util.c xutil.c conf.c xevents.c group.c \
-		kbfunc.c mousefunc.c parse.y
+		kbfunc.c mousefunc.c parse.y colorize.c
 
 OBJS=		calmwm.o screen.o xmalloc.o client.o menu.o \
 		search.o util.o xutil.o conf.o xevents.o group.o \
 		kbfunc.o mousefunc.o strlcpy.o strlcat.o y.tab.o \
-		strtonum.o fgetln.o
+		strtonum.o fgetln.o colorize.o
 
 CPPFLAGS+=	`pkg-config --cflags fontconfig x11 xft xinerama xrandr`
 

--- a/calmwm.h
+++ b/calmwm.h
@@ -302,6 +302,7 @@ struct conf {
 	struct ignore_q		 ignoreq;
 	struct cmd_q		 cmdq;
 #define	CONF_STICKY_GROUPS		0x0001
+#define	CONF_COLORIZE_SSH		0x0002
 	int			 flags;
 #define CONF_BWIDTH			1
 	int			 bwidth;
@@ -582,5 +583,9 @@ char			*xstrdup(const char *);
 int			 xasprintf(char **, const char *, ...)
 			    __attribute__((__format__ (printf, 2, 3)))
 			    __attribute__((__nonnull__ (2)));
+
+long			 crc24(char *);
+long			 tint(long);
+long			 shade(long);
 
 #endif /* _CALMWM_H_ */

--- a/colorize.c
+++ b/colorize.c
@@ -1,0 +1,67 @@
+/* $Id$ */
+/*
+ * Copyright (c) 2015 Dimitri Sokolyuk <demon@dim13.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "calmwm.h"
+
+#define CRC24_INIT	0x0B704CEL
+#define CRC24_POLY	0x1864CFBL
+
+long
+crc24(char *s)
+{
+	long crc;
+	int i;
+
+	for (crc = CRC24_INIT; *s; s++) {
+		crc ^= *s << 0x10;
+		for (i = 0; i < 8; i++) {
+			crc <<= 1;
+			if (crc & 0x1000000)
+				crc ^= CRC24_POLY;
+		}
+	}
+
+	return crc;
+}
+
+long
+shade(long c)
+{
+	unsigned char r = c >> 0x10;
+	unsigned char g = c >> 0x08;
+	unsigned char b = c;
+
+	r >>= 2;
+	g >>= 2;
+	b >>= 2;
+
+	return (r << 0x10) | (g << 0x8) | b;
+}
+
+long
+tint(long c)
+{
+	unsigned char r = c >> 0x10;
+	unsigned char g = c >> 0x08;
+	unsigned char b = c;
+
+	r += (UCHAR_MAX - r) >> 1;
+	g += (UCHAR_MAX - g) >> 1;
+	b += (UCHAR_MAX - b) >> 1;
+
+	return (r << 0x10) | (g << 0x8) | b;
+}

--- a/cwmrc.5
+++ b/cwmrc.5
@@ -131,6 +131,9 @@ Set the color of the border of a window indicating urgency.
 .It Ic color ungroupborder Ar color
 Set the color of the border while ungrouping a window.
 .Pp
+.It Ic colorize Ic yes Ns \&| Ns Ic no
+Colorize SSH terminals with hashed colors.
+.Pp
 .It Ic command Ar name path
 Every
 .Ar name

--- a/parse.y
+++ b/parse.y
@@ -70,7 +70,7 @@ typedef struct {
 
 %}
 
-%token	FONTNAME STICKY GAP MOUSEBIND
+%token	FONTNAME STICKY COLORIZE GAP MOUSEBIND
 %token	AUTOGROUP BIND COMMAND IGNORE
 %token	YES NO BORDERWIDTH MOVEAMOUNT
 %token	COLOR SNAPDIST
@@ -118,6 +118,12 @@ main		: FONTNAME STRING		{
 				conf->flags &= ~CONF_STICKY_GROUPS;
 			else
 				conf->flags |= CONF_STICKY_GROUPS;
+		}
+		| COLORIZE yesno {
+			if ($2 == 0)
+				conf->flags &= ~CONF_COLORIZE_SSH;
+			else
+				conf->flags |= CONF_COLORIZE_SSH;
 		}
 		| BORDERWIDTH NUMBER {
 			if ($2 < 0 || $2 > UINT_MAX) {
@@ -276,6 +282,7 @@ lookup(char *s)
 		{ "bind",		BIND},
 		{ "borderwidth",	BORDERWIDTH},
 		{ "color",		COLOR},
+		{ "colorize",		COLORIZE},
 		{ "command",		COMMAND},
 		{ "font",		FONTCOLOR},
 		{ "fontname",		FONTNAME},


### PR DESCRIPTION
I would like to introduce a simple, but very useful hack. It boils down to colorization of remote connections (ssh) based on a hash of remote hostname. This way it is much easier to distinguish between a bunch of remote connectoins (meta-dot command). Colors are "sticky" to the hostname, so multiple connections to the same host get a same color. It would be very nice, if this patch manages into upstream.